### PR TITLE
Restrict “current” directory usage

### DIFF
--- a/system/pathway-system.cabal
+++ b/system/pathway-system.cabal
@@ -134,6 +134,9 @@ library
     transformers ^>= {0.5.6, 0.6.1},
   exposed-modules:
     Filesystem.Path
+    Filesystem.Path.Compat
+  other-modules:
+    Filesystem.Path.Internal
 
 test-suite doctests
   import: defaults

--- a/system/src/Filesystem/Path/Compat.hs
+++ b/system/src/Filesystem/Path/Compat.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE Trustworthy #-}
+-- "System.Directory" has inconsistent Safe Haskell modes across versions. We
+-- can’t conditionalize the Safe Haskell extension (because it forces Safe
+-- Haskell-using consumers to conditionalize), so this silences the fact that
+-- this module is inferred ‘Safe’ in some configurations.
+{-# OPTIONS_GHC -Wno-safe -Wno-trustworthy-safe #-}
+
+-- | Operations that don’t fit with the philosophy of this library, but that
+-- help with interoperability with other code.
+module Filesystem.Path.Compat
+  ( withCurrentDirectory,
+  )
+where
+
+import safe "base" Control.Category ((.))
+import safe "base" Data.Either (Either)
+import safe "base" System.IO (IO)
+import "directory" System.Directory qualified as Dir
+import safe "pathway" Data.Path (Path, Relativity (Abs), Type (Dir))
+import safe "transformers" Control.Monad.Trans.Class (lift)
+import safe "transformers" Control.Monad.Trans.Except (ExceptT)
+import safe "this" Filesystem.Path qualified as Path
+import safe "this" Filesystem.Path.Internal (PathComponent, toPathRep)
+
+-- | Instead of working with the “current” directory, you should pass explicit
+--   absolute paths. However, for compatibility with other code that relies on
+--   the “current” directory, this is made available so that it can be scoped
+--   around such calls.
+--
+--  __NB__: Like the underlying `Dir.withCurrentDirectory`, this is _not_ thread-safe.
+withCurrentDirectory ::
+  Path 'Abs 'Dir PathComponent ->
+  IO a ->
+  ExceptT (Either Path.GetFailure Path.SetFailure) IO a
+withCurrentDirectory newCurDir = lift . Dir.withCurrentDirectory (toPathRep newCurDir)

--- a/system/src/Filesystem/Path/Internal.hs
+++ b/system/src/Filesystem/Path/Internal.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE Safe #-}
+
+-- | Non-public definitions that are relied on by multiple modules in this
+-- library. This may eventually be a public module for providing alternative
+-- implementations (like `FilePath` vs `OsPath`).
+module Filesystem.Path.Internal
+  ( PathRep,
+    PathComponent,
+    toPathRep,
+  )
+where
+
+import "base" Data.Kind qualified as Kind
+import "base" Data.String (String)
+import "filepath" System.FilePath (FilePath)
+import "pathway" Data.Path (Path, Pathy)
+import "pathway" Data.Path qualified as Path
+import "pathway" Data.Path.Format qualified as Format
+
+-- |
+--
+--  __NB__: This is currently an alias for `FilePath`, but it is intended to
+--          switch to `OsPath` in future (for GHCs recent enough to have it),
+--          once there is code in place to avoid converting back and forth for
+--          parsing, etc.
+type PathRep :: Kind.Type
+type PathRep = FilePath
+
+-- | In both the `FilePath` and `OsPath` versions, this represents the same type
+--   as `PathRep`, but the distinction indicates whether a path (where, for
+--   example, literal backslashes need to be escaped for POSIX) or a single
+--   component (where no characters are escaped) is held.
+type PathComponent :: Kind.Type
+type PathComponent = String
+
+toPathRep :: (Pathy rel typ) => Path rel typ PathComponent -> PathRep
+toPathRep = Path.toText Format.local


### PR DESCRIPTION
This removes `setCurrentDirectory` and moves `withCurrentDirectory` to a `Compat` module (because it can be very helpful when calling external code that has expectations around using the current directory).

It also improves the relevant docs a bit.