### PR TITLE
Bump pathway's dependencies to allow building with GHC 9.12

### DIFF
--- a/internal/pathway-internal.cabal
+++ b/internal/pathway-internal.cabal
@@ -46,7 +46,7 @@ custom-setup
     --       requires it to have _some_ upper bound. (Since there’s no direct
     --       dependency, it doesn’t use PVP bounds.)
     Cabal >= 3.0 && < 99,
-    base ^>= {4.17.1, 4.18.0, 4.19.0, 4.20.0},
+    base ^>= {4.17.1, 4.18.0, 4.19.0, 4.20.0, 4.21.0},
     cabal-doctest ^>= {1.0.0},
 
 flag noisy-deprecations
@@ -82,7 +82,7 @@ common GHC2024
 common defaults
   import: GHC2024
   build-depends:
-    base ^>= {4.17.1, 4.18.0, 4.19.0, 4.20.0},
+    base ^>= {4.17.1, 4.18.0, 4.19.0, 4.20.0, 4.21.0},
   ghc-options:
     -Weverything
     -- This one just reports unfixable things, AFAICT.
@@ -126,7 +126,7 @@ library
   hs-source-dirs:
     src
   build-depends:
-    yaya ^>= {0.6.2},
+    yaya ^>= {0.6.2, 0.7.0},
   exposed-modules:
     Data.Path.Internal
 

--- a/path/pathway-path.cabal
+++ b/path/pathway-path.cabal
@@ -46,7 +46,7 @@ custom-setup
     --       requires it to have _some_ upper bound. (Since there’s no direct
     --       dependency, it doesn’t use PVP bounds.)
     Cabal >= 3.0 && < 99,
-    base ^>= {4.17.1, 4.18.0, 4.19.0, 4.20.0},
+    base ^>= {4.17.1, 4.18.0, 4.19.0, 4.20.0, 4.21.0},
     cabal-doctest ^>= {1.0.0},
 
 flag noisy-deprecations
@@ -82,7 +82,7 @@ common GHC2024
 common defaults
   import: GHC2024
   build-depends:
-    base ^>= {4.17.1, 4.18.0, 4.19.0, 4.20.0},
+    base ^>= {4.17.1, 4.18.0, 4.19.0, 4.20.0, 4.21.0},
   ghc-options:
     -Weverything
     -- This one just reports unfixable things, AFAICT.
@@ -130,8 +130,8 @@ library
     path ^>= {0.9.1},
     pathway ^>= {0.0.1},
     pathway-internal ^>= {0.0.1},
-    yaya ^>= {0.6.2},
-    yaya-unsafe ^>= {0.4.1},
+    yaya ^>= {0.6.2, 0.7.0},
+    yaya-unsafe ^>= {0.4.1, 0.5.0},
   exposed-modules:
     Data.Path.Integration.Path
 

--- a/pathway/pathway.cabal
+++ b/pathway/pathway.cabal
@@ -46,7 +46,7 @@ custom-setup
     --       requires it to have _some_ upper bound. (Since there’s no direct
     --       dependency, it doesn’t use PVP bounds.)
     Cabal >= 3.0 && < 99,
-    base ^>= {4.17.1, 4.18.0, 4.19.0, 4.20.0},
+    base ^>= {4.17.1, 4.18.0, 4.19.0, 4.20.0, 4.21.0},
     cabal-doctest ^>= {1.0.0},
 
 flag noisy-deprecations
@@ -82,7 +82,7 @@ common GHC2024
 common defaults
   import: GHC2024
   build-depends:
-    base ^>= {4.17.1, 4.18.0, 4.19.0, 4.20.0},
+    base ^>= {4.17.1, 4.18.0, 4.19.0, 4.20.0, 4.21.0},
   ghc-options:
     -Weverything
     -- This one just reports unfixable things, AFAICT.
@@ -130,11 +130,11 @@ library
     extra ^>= {1.7.7, 1.8.1},
     megaparsec ^>= {9.2.0, 9.5.0, 9.6.1, 9.7.0},
     pathway-internal ^>= {0.0.1},
-    template-haskell ^>= {2.19.0, 2.20.0, 2.21.0, 2.22.0},
+    template-haskell ^>= {2.19.0, 2.20.0, 2.21.0, 2.22.0, 2.23.0},
     text ^>= {2.0.2, 2.1},
-    yaya ^>= {0.6.2},
-    yaya-containers ^>= {0.1.2},
-    yaya-unsafe ^>= {0.4.1},
+    yaya ^>= {0.6.2, 0.7.0},
+    yaya-containers ^>= {0.1.2, 0.2.0},
+    yaya-unsafe ^>= {0.4.1, 0.5.0},
   exposed-modules:
     Data.Path
     Data.Path.Directory

--- a/pathway/src/Data/Path.hs
+++ b/pathway/src/Data/Path.hs
@@ -244,7 +244,7 @@ class RelOps rel where
     Maybe (Path ('Rel 'True) typ rep)
 
   -- | Like `maybeRoute`, but shortens the path as much as possible. This can
-  --   only makes a difference when both paths have the same amount of
+  --   only make a difference when both paths have the same amount of
   --   reparenting. E.g.
   --
   -- >>> toText Format.posix <$> maybeMinimalRoute @('Rel 'True) @Text [posix|../d/e/|] [posix|../d/f/|]

--- a/quickcheck/pathway-quickcheck.cabal
+++ b/quickcheck/pathway-quickcheck.cabal
@@ -46,7 +46,7 @@ custom-setup
     --       requires it to have _some_ upper bound. (Since there’s no direct
     --       dependency, it doesn’t use PVP bounds.)
     Cabal >= 3.0 && < 99,
-    base ^>= {4.17.1, 4.18.0, 4.19.0, 4.20.0},
+    base ^>= {4.17.1, 4.18.0, 4.19.0, 4.20.0, 4.21.0},
     cabal-doctest ^>= {1.0.0},
 
 flag noisy-deprecations
@@ -82,7 +82,7 @@ common GHC2024
 common defaults
   import: GHC2024
   build-depends:
-    base ^>= {4.17.1, 4.18.0, 4.19.0, 4.20.0},
+    base ^>= {4.17.1, 4.18.0, 4.19.0, 4.20.0, 4.21.0},
   ghc-options:
     -Weverything
     -- This one just reports unfixable things, AFAICT.
@@ -129,8 +129,8 @@ library
     QuickCheck ^>= {2.14.3, 2.15.0},
     pathway-internal ^>= {0.0.1},
     quickcheck-instances ^>= {0.3.29},
-    yaya ^>= {0.6.2},
-    yaya-quickcheck ^>= {0.2.0},
+    yaya ^>= {0.6.2, 0.7.0},
+    yaya-quickcheck ^>= {0.2.0, 0.3.0},
   exposed-modules:
     Test.Path.QuickCheck
 

--- a/system/pathway-system.cabal
+++ b/system/pathway-system.cabal
@@ -46,7 +46,7 @@ custom-setup
     --       requires it to have _some_ upper bound. (Since there’s no direct
     --       dependency, it doesn’t use PVP bounds.)
     Cabal >= 3.0 && < 99,
-    base ^>= {4.17.1, 4.18.0, 4.19.0, 4.20.0},
+    base ^>= {4.17.1, 4.18.0, 4.19.0, 4.20.0, 4.21.0},
     cabal-doctest ^>= {1.0.0},
 
 flag noisy-deprecations
@@ -82,7 +82,7 @@ common GHC2024
 common defaults
   import: GHC2024
   build-depends:
-    base ^>= {4.17.1, 4.18.0, 4.19.0, 4.20.0},
+    base ^>= {4.17.1, 4.18.0, 4.19.0, 4.20.0, 4.21.0},
   ghc-options:
     -Weverything
     -- This one just reports unfixable things, AFAICT.
@@ -130,7 +130,7 @@ library
     filepath ^>= {1.4.2, 1.5.2},
     megaparsec ^>= {9.2.0, 9.5.0, 9.6.1, 9.7.0},
     pathway ^>= {0.0.1},
-    time ^>= {1.12.2},
+    time ^>= {1.12.2, 1.14},
     transformers ^>= {0.5.6, 0.6.1},
   exposed-modules:
     Filesystem.Path


### PR DESCRIPTION
I've tried with GHC 9.14 too, but that comes with `base-4.22.0.0`, and you have an indirect dependency on `these`, the most recent version of which, as you can see [here](https://hackage.haskell.org/package/these), requires that `base` be `< 4.22`.
```
Could not resolve dependencies:
[__0] trying: pathway-0.0.1.0 (user goal)
[__1] trying: yaya-unsafe-0.5.0.0 (dependency of pathway)
[__2] trying: lens-5.3.6 (dependency of yaya-unsafe)
[__3] trying: these-1.2.1 (dependency of lens)
[__4] next goal: base (dependency of pathway)
[__4] rejecting: base-4.22.0.0/installed-2547 (conflict: these => base>=4.12.0.0 && <4.22)
```