### PR TITLE
WIP - Fix #25

### DIFF
--- a/internal/pathway-internal.cabal
+++ b/internal/pathway-internal.cabal
@@ -196,7 +196,9 @@ library
     yaya ^>= {0.6.2, 0.7.0},
   exposed-modules:
     Data.Path.Internal
+    Data.Path.Internal.List
     Data.Path.Internal.Relativity
+    Data.Path.Internal.Resolution
     Data.Path.Internal.Type
 
 -- NB: This package can’t have any QuickCheck-based doctests, because those

--- a/internal/src/Data/Path/Internal.hs
+++ b/internal/src/Data/Path/Internal.hs
@@ -1,16 +1,17 @@
 {-# LANGUAGE Trustworthy #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilyDependencies #-}
 -- __NB__: Because of the nested `Parents` and `Filename` constraints.
 {-# LANGUAGE UndecidableInstances #-}
-{-# OPTIONS_GHC -Wno-orphans #-}
 -- "GHC.Natural" is ‘Unsafe’ before base 4.14.4. We can’t conditionalize the
 -- Safe Haskell extension (because it forces Safe Haskell-using consumers to
 -- conditionalize), so this silences the fact that this module is inferred
 -- ‘Safe’ in some configurations. We should be able to remove this (and this
 -- module made ‘Safe’) once base-4.14.4 is the oldest supported version.
 {-# OPTIONS_GHC -Wno-safe -Wno-trustworthy-safe #-}
+{-# OPTIONS_GHC -Wno-unused-matches #-}
 {-# OPTIONS_GHC -fplugin-opt=NoRecursion:ignore-methods:sconcat #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module Data.Path.Internal
   ( List (List),
@@ -22,113 +23,56 @@ module Data.Path.Internal
   )
 where
 
-import safe "base" Control.Applicative (Applicative, liftA2, pure)
-import safe "base" Control.Category ((.))
-import safe "base" Data.Bifoldable (Bifoldable, bifoldr)
-import safe "base" Data.Bitraversable (Bitraversable, bisequenceA, bitraverse)
-import safe "base" Data.Bool (Bool (False, True))
-import safe "base" Data.Eq (Eq)
-import safe "base" Data.Foldable (Foldable, foldr, sum)
-import safe "base" Data.Function (($))
-import safe "base" Data.Functor (Functor, fmap, (<$>))
+--import safe "base" Data.Eq (Eq)
+--import safe "base" Data.Foldable (Foldable)
+--import safe "base" Data.Functor (Functor)
 import safe "base" Data.Functor.Const (Const (Const))
-import safe "base" Data.Functor.Identity (Identity)
+import safe "base" Data.Functor.Identity (Identity (runIdentity))
 import safe "base" Data.Kind qualified as Kind
 import safe "base" Data.Monoid (Monoid, mempty)
-import safe "base" Data.Ord (Ord)
+--import safe "base" Data.Ord (Ord)
 import safe "base" Data.Proxy (Proxy (Proxy))
 import safe "base" Data.Semigroup (Semigroup, stimes, stimesMonoid, (<>))
-import safe "base" Data.Traversable (Traversable, traverse)
-import safe "base" GHC.Generics (Generic, Generic1)
+import safe "base" GHC.Generics (Generic)
 -- TODO: `minusNaturalMaybe` is exported from Numeric.Natural starting with base-4.18 (GHC 9.6).
-import "base" GHC.Natural (minusNaturalMaybe)
 import safe "base" Numeric.Natural (Natural)
-import safe "base" Text.Read (Read)
-import safe "base" Text.Show (Show)
-import safe "yaya" Yaya.Applied (drop, length)
-import safe "yaya" Yaya.Fold
-  ( Mu,
-    Projectable,
-    Recursive,
-    Steppable,
-    cata,
-    embed,
-    project,
-  )
-import safe "yaya" Yaya.Functor (DFunctor, firstMap)
-import safe "yaya" Yaya.Pattern (Maybe, XNor (Both, Neither), xnor)
+--import safe "base" Text.Read (Read)
+--import safe "base" Text.Show (Show)
+--import safe "yaya" Yaya.Fold (embed)
+import safe "yaya" Yaya.Pattern (Maybe (Nothing, Just))
+import "this" Data.Path.Internal.List (List (List))
 import "this" Data.Path.Internal.Relativity (Relativity (Abs, Any, Rel))
+import "this" Data.Path.Internal.Resolution (Resolution (Res, Unres))
 import "this" Data.Path.Internal.Type (Type (Dir, File))
 import "this" Data.Path.Internal.Type qualified as Type (Type (Any))
-import safe "base" Prelude ((+))
+import safe "base" Prelude (undefined, last, (<$>), init)
 
 -- | The `Parents` closed type family maps `Relativity` to types that encode the
---  number of leading @../@ in the path.
+--  number of leading @../@ (or the absence thereof) in the path.
 type Parents :: Relativity -> Kind.Type
 type family Parents rel = result | result -> rel where
   Parents 'Abs = ()
-  Parents ('Rel 'False) = Proxy Natural
-  Parents ('Rel 'True) = Natural
+  Parents 'Rel = Proxy Natural
   Parents 'Any = Maybe Natural
 
+-- | The `Filename` closed type family maps each `Type` (together with a
+--  generic representation type `Kind.Type`) to a type that encodes the
+--  filename (or the absence thereof) in the path.
 type Filename :: Type -> Kind.Type -> Kind.Type
 type family Filename typ = result | result -> typ where
   Filename 'Dir = Const ()
   Filename 'File = Identity
   Filename 'Type.Any = Maybe
 
--- | A strict sequence.
---
---  __TODO__: Move this upstream to Yaya.
-type List :: Kind.Type -> Kind.Type
-newtype List a = List (Mu (XNor a))
-  deriving stock (Eq, Generic, Ord, Read, Show)
+type Directories :: Resolution -> Relativity -> Kind.Type -> Kind.Type
+type family Directories res rel rep = result | result -> rep rel res where
+  -- XXX: we assume that all lists here have directories from deep to shallow
+  -- going from left to right
+  Directories 'Res   'Rel rep = Maybe (rep, [Maybe rep])
+  Directories 'Res   'Abs rep = Identity [rep]
+  Directories 'Unres 'Rel rep = [Maybe rep]
+  Directories 'Unres 'Abs rep = (rep, [Maybe rep])
 
-instance Projectable (->) (List a) (XNor a) where
-  project (List mu) = List <$> project mu
-
-instance Recursive (->) (List a) (XNor a) where
-  cata φ (List mu) = cata φ mu
-
-instance Steppable (->) (List a) (XNor a) where
-  embed = List . embed . fmap (\(List mu) -> mu)
-
-instance Semigroup (List a) where
-  List mu <> List mu' = List $ mu <> mu'
-  stimes = stimesMonoid
-
-instance Monoid (List a) where
-  mempty = List mempty
-
-instance Foldable List where
-  foldr f z (List mu) = cata (xnor z f) mu
-
-instance Functor List where
-  fmap f (List mu) = List (firstMap f mu)
-
-instance Bifoldable XNor where
-  bifoldr f g z = xnor z \a -> f a . (`g` z)
-
-instance Bitraversable XNor where
-  bitraverse f g = xnor (pure Neither) \a -> liftA2 Both (f a) . g
-
--- |
---
---  __TODO__: Move this – "Yaya.Functor" would be a good place, but this depends
---            on things from "Yaya.Fold", which is downstream from that.
-firstTraverse ::
-  forall d b f a c u.
-  ( Recursive (->) (d (b (f c))) (b (f c)),
-    Steppable (->) u (b c),
-    DFunctor d,
-    Bitraversable b,
-    Applicative f
-  ) =>
-  (a -> f c) -> d (b a) -> f u
-firstTraverse f = cata @_ @_ @(b (f c)) (fmap embed . bisequenceA) . firstMap f
-
-instance Traversable List where
-  traverse f (List mu) = List <$> firstTraverse f mu
 
 -- | This provides a dozen variants of a filesystem path type, split into four
 --   categories:
@@ -161,141 +105,152 @@ instance Traversable List where
 --   these paths are ambiguous in any way – it‘s only a matter of which
 --   information is visible at the type level. E.g., `AnyPath` can be inspected
 --   to determine if it’s absolute or relative, file or directory.
-type Path :: Relativity -> Type -> Kind.Type -> Kind.Type
-data Path rel typ rep = Path
+type Path :: Resolution -> Relativity -> Type -> Kind.Type -> Kind.Type
+data Path res rel typ rep = Path
   { parents :: Parents rel,
-    directories :: List rep,
+    directories :: Directories res rel rep,
     filename :: Filename typ rep
   }
   deriving stock (Generic)
-  deriving stock (Generic1)
 
-deriving stock instance
-  (Eq (Parents rel), Eq (Filename typ rep), Eq rep) => Eq (Path rel typ rep)
+--deriving stock instance
+--  (Eq (Parents rel), Eq (Filename typ rep), Eq rep) => Eq (Path res rel typ rep)
+--
+--deriving stock instance
+--  (Ord (Parents rel), Ord (Filename typ rep), Ord rep) => Ord (Path res rel typ rep)
+--
+--deriving stock instance
+--  (Read (Parents rel), Read (Filename typ rep), Read rep) =>
+--  Read (Path res rel typ rep)
 
-deriving stock instance
-  (Ord (Parents rel), Ord (Filename typ rep), Ord rep) => Ord (Path rel typ rep)
+--deriving stock instance
+--  (Show (Parents rel), Show (Filename typ rep), Show rep) =>
+--  Show (Path res rel typ rep)
 
-deriving stock instance
-  (Read (Parents rel), Read (Filename typ rep), Read rep) =>
-  Read (Path rel typ rep)
+--deriving stock instance
+--  (Foldable (Filename typ)) => Foldable (Path res rel typ)
+--
+--deriving stock instance
+--  (Functor (Filename typ)) => Functor (Path res rel typ)
+--
+--deriving stock instance
+--  (Traversable (Filename typ)) => Traversable (Path res rel typ)
 
-deriving stock instance
-  (Show (Parents rel), Show (Filename typ rep), Show rep) =>
-  Show (Path rel typ rep)
+-- | Type-level ternary function to compute TODO. add doc
+-- TODO: also `Min` needs to change name.
+type Min :: (Resolution, Relativity) -> Resolution -> Resolution
+type family Min a b where
+  Min '( 'Res, 'Rel) 'Res = 'Res
+  Min _ _ = 'Unres
 
-deriving stock instance
-  (Foldable (Filename typ)) => Foldable (Path rel typ)
+-- | TODO: update doc
+type TotalOps :: Resolution -> Relativity -> Resolution -> Kind.Constraint
+class TotalOps res rel res' where
+  (<<>>) :: Directories res' 'Rel rep -> Directories res rel rep -> Directories (Min '(res, rel) res') rel rep
 
-deriving stock instance
-  (Functor (Filename typ)) => Functor (Path rel typ)
-
-deriving stock instance
-  (Traversable (Filename typ)) => Traversable (Path rel typ)
-
-type TotalOps :: Relativity -> Bool -> Relativity -> Kind.Constraint
-class TotalOps rel par rel' | rel par -> rel' where
-  -- | Concatenate two paths.
-  --
-  --  __NB__: The precedence is one higher than `System.FilePath.</>` and
-  --         `Path.</>` so that cases like the one below can be written without
-  --          parentheses.
-  --
-  --        > toText Format.posix
-  --        >   <$> [posix|/|] </?> [posix|usr/|] </> [posix|bin/|] </> [posix|env|]
-  --
-  --          The precedence is tricky, because `<>` also has the same precedence,
-  --          but only applies to relative paths, so you can’t mix `<>` and `</>`.
-  --          E.g., ideally you’d be able to write @`toText` `<$>` abs `</?>` rel1
-  --         `<>` rel2 `</>` file@ without parens, but if you could, then
-  --          @`toText` `<$>` abs `</?>` rel1 `</>` rel2 `</>` file@ would need
-  --          parens either @`toText` `<$>` (abs `</?>` rel1 `</>` rel2 `</>`
-  --          file)@ or @`toText` `<$>` abs `</?>` (rel1 `</>` rel2 `</>` file)@.
-  --          Unless you can mix an associative and non-associative operator of
-  --          the same precedence …
-  (</>) :: Path rel 'Dir rep -> Path ('Rel par) typ rep -> Path rel' typ rep
+-- | Concatenate two paths.  TODO: update doc
+--  __NB__: The precedence is one higher than `System.FilePath.</>` and
+--         `Path.</>` so that cases like the one below can be written without
+--          parentheses.
+--
+--        > toText Format.posix
+--        >   <$> [posix|/|] </?> [posix|usr/|] </> [posix|bin/|] </> [posix|env|]
+--
+--          The precedence is tricky, because `<>` also has the same precedence,
+--          but only applies to relative paths, so you can’t mix `<>` and `</>`.
+--          E.g., ideally you’d be able to write @`toText` `<$>` abs `</?>` rel1
+--         `<>` rel2 `</>` file@ without parens, but if you could, then
+--          @`toText` `<$>` abs `</?>` rel1 `</>` rel2 `</>` file@ would need
+--          parens either @`toText` `<$>` (abs `</?>` rel1 `</>` rel2 `</>`
+--          file)@ or @`toText` `<$>` abs `</?>` (rel1 `</>` rel2 `</>` file)@.
+--          Unless you can mix an associative and non-associative operator of
+--          the same precedence …
+(</>) :: TotalOps res rel res' => Path res rel 'Dir rep -> Path res' 'Rel typ rep -> Path (Min '(res, rel) res') rel typ rep
+parent </> child =
+  Path
+    { parents = undefined,
+      directories = directories child <<>> directories parent,
+      filename = filename child
+    }
 
 infixr 5 </>
 
-instance TotalOps 'Any 'False 'Any where
-  parent </> child =
-    Path
-      { parents = parents parent,
-        directories = directories child <> directories parent,
-        filename = filename child
-      }
+instance TotalOps 'Res 'Rel 'Res where
+  child <<>> Nothing = child
+  Nothing <<>> parent = parent
+  Just (c, cs) <<>> Just (p, ps) = Just (p, cs <> (Just c:ps))
 
-instance TotalOps ('Rel 'True) 'True ('Rel 'True) where
-  parent </> child =
-    Path
-      { parents =
-          foldr (+) (parents parent)
-            . minusNaturalMaybe (parents child)
-            . length
-            $ directories parent,
-        directories =
-          directories child <> drop (parents child) (directories parent),
-        filename = filename child
-      }
+instance TotalOps 'Res 'Rel 'Unres where
+  child <<>> Nothing = child
+  child <<>> Just (p, ps) = child <> ps <> [Just p]
 
-instance TotalOps ('Rel 'True) 'False ('Rel 'True) where
-  parent </> child =
-    Path
-      { parents = parents parent,
-        directories = directories child <> directories parent,
-        filename = filename child
-      }
+instance TotalOps 'Res 'Abs 'Res where
+  Nothing <<>> parent = (last parent', Just <$> init (parent'))
+    where parent' = runIdentity parent
+  Just (c, cs) <<>> parent = (last parent', cs <> (Just <$> init (c:parent')))
+    where parent' = runIdentity parent
 
-instance TotalOps ('Rel 'False) 'True ('Rel 'True) where
-  parent </> child =
-    Path
-      { parents =
-          sum . minusNaturalMaybe (parents child) . length $ directories parent,
-        directories =
-          directories child <> drop (parents child) (directories parent),
-        filename = filename child
-      }
+instance TotalOps 'Res 'Abs 'Unres where
+  child <<>> parent = (last parent', child <> (Just <$> init parent'))
+    where parent' = runIdentity parent
 
-instance TotalOps ('Rel 'False) 'False ('Rel 'False) where
-  parent </> child =
-    Path
-      { parents = Proxy,
-        directories = directories child <> directories parent,
-        filename = filename child
-      }
+instance TotalOps 'Res 'Any 'Res where
+  child <<>> parent = undefined -- TODO
 
-instance TotalOps 'Abs 'False 'Abs where
-  parent </> child =
-    Path
-      { parents = (),
-        directories = directories child <> directories parent,
-        filename = filename child
-      }
+instance TotalOps 'Res 'Any 'Unres where
+  child <<>> parent = undefined -- TODO
+
+instance TotalOps 'Unres 'Rel 'Res where
+  Nothing <<>> parent = parent
+  Just (c, cs) <<>> parent = cs <> (Just c:parent)
+
+instance TotalOps 'Unres 'Rel 'Unres where
+  (<<>>) = (<>)
+
+instance TotalOps 'Unres 'Abs 'Res where
+  Nothing <<>> parents = parents
+  Just (c, cs) <<>> (p, ps) = (p, cs <> (Just c:ps))
+
+instance TotalOps 'Unres 'Abs 'Unres where
+  child <<>> (p, ps) = (p, child <> ps)
+
+instance TotalOps 'Unres 'Any 'Res where
+  child <<>> parent = undefined -- TODO
+
+instance TotalOps 'Unres 'Any 'Unres where
+  child <<>> parent = undefined -- TODO
 
 -- | This does /not/ represent the “current directory” as in the absolute path
 --   from which the program was run or something, but rather the path “./”.
-current :: Path ('Rel 'False) 'Dir rep
+current :: Path 'Res 'Rel 'Dir rep
 current =
-  Path {parents = Proxy, directories = embed Neither, filename = Const ()}
+  Path {parents = Proxy, directories = Nothing, filename = Const ()}
 
 -- | Forget that a relative path doesn’t have any parents.
-weaken :: Path ('Rel 'False) typ rep -> Path ('Rel 'True) typ rep
-weaken path = path {parents = 0}
+weaken :: Path 'Res 'Rel typ rep -> Path 'Unres 'Rel typ rep
+weaken Path{..} =
+  Path { parents = undefined,
+         directories = case directories of
+                          Nothing -> []
+                          Just (a, as) -> as <> [Just a]
+       , filename = filename }
+
+-- unsafeResolve :: Path 'Unres rel typ rep -> Maybe (Path 'Res rel typ rep)
 
 -- | Only relative directories form a semigroup under `</>`.
-instance Semigroup (Path ('Rel 'False) 'Dir rep) where
+instance Semigroup (Path 'Res 'Rel 'Dir rep) where
   (<>) = (</>)
   stimes = stimesMonoid
 
 -- | Only relative directories form a semigroup under `</>`.
-instance Semigroup (Path ('Rel 'True) 'Dir rep) where
+instance Semigroup (Path 'Unres 'Rel 'Dir rep) where
   (<>) = (</>)
   stimes = stimesMonoid
 
--- | Only relative directories form a monoid under concatenation.
-instance Monoid (Path ('Rel 'False) 'Dir rep) where
+---- | Only relative directories form a monoid under concatenation.
+instance Monoid (Path 'Res 'Rel 'Dir rep) where
   mempty = current
 
 -- | Only relative directories form a monoid under concatenation.
-instance Monoid (Path ('Rel 'True) 'Dir rep) where
+instance Monoid (Path 'Unres 'Rel 'Dir rep) where
   mempty = weaken current

--- a/internal/src/Data/Path/Internal/List.hs
+++ b/internal/src/Data/Path/Internal/List.hs
@@ -1,0 +1,94 @@
+{-# LANGUAGE Safe #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -fplugin-opt=NoRecursion:ignore-methods:sconcat #-}
+
+module Data.Path.Internal.List
+  ( List (List),
+    firstTraverse,
+  )
+where
+
+import "base" Control.Applicative (Applicative, liftA2, pure)
+import "base" Control.Category ((.))
+import "base" Data.Bifoldable (Bifoldable, bifoldr)
+import "base" Data.Bitraversable (Bitraversable, bisequenceA, bitraverse)
+import "base" Data.Eq (Eq)
+import "base" Data.Foldable (Foldable, foldr)
+import "base" Data.Function (($))
+import "base" Data.Functor (Functor, fmap, (<$>))
+import "base" Data.Kind qualified as Kind
+import "base" Data.Monoid (Monoid, mempty)
+import "base" Data.Ord (Ord)
+import "base" Data.Semigroup (Semigroup, stimes, stimesMonoid, (<>))
+import "base" Data.Traversable (Traversable, traverse)
+import "base" GHC.Generics (Generic)
+import "base" Text.Read (Read)
+import "base" Text.Show (Show)
+-- This has the `Semigroup` and `Monoid` instances for `Mu`.
+import "yaya" Yaya.Applied ()
+import "yaya" Yaya.Fold
+  ( Mu,
+    Projectable,
+    Recursive,
+    Steppable,
+    cata,
+    embed,
+    project,
+  )
+import "yaya" Yaya.Functor (DFunctor, firstMap)
+import "yaya" Yaya.Pattern (XNor (Both, Neither), xnor)
+
+-- | A strict sequence.
+--
+--  __TODO__: Move this upstream to Yaya.
+type List :: Kind.Type -> Kind.Type
+newtype List a = List (Mu (XNor a))
+  deriving stock (Eq, Generic, Ord, Read, Show)
+
+instance Projectable (->) (List a) (XNor a) where
+  project (List mu) = List <$> project mu
+
+instance Recursive (->) (List a) (XNor a) where
+  cata φ (List mu) = cata φ mu
+
+instance Steppable (->) (List a) (XNor a) where
+  embed = List . embed . fmap (\(List mu) -> mu)
+
+instance Semigroup (List a) where
+  List mu <> List mu' = List $ mu <> mu'
+  stimes = stimesMonoid
+
+instance Monoid (List a) where
+  mempty = List mempty
+
+instance Foldable List where
+  foldr f z (List mu) = cata (xnor z f) mu
+
+instance Functor List where
+  fmap f (List mu) = List (firstMap f mu)
+
+instance Bifoldable XNor where
+  bifoldr f g z = xnor z \a -> f a . (`g` z)
+
+instance Bitraversable XNor where
+  bitraverse f g = xnor (pure Neither) \a -> liftA2 Both (f a) . g
+
+-- |
+--
+--  __TODO__: Move this – "Yaya.Functor" would be a good place, but this depends
+--            on things from "Yaya.Fold", which is downstream from that.
+firstTraverse ::
+  forall d b f a c u.
+  ( Recursive (->) (d (b (f c))) (b (f c)),
+    Steppable (->) u (b c),
+    DFunctor d,
+    Bitraversable b,
+    Applicative f
+  ) =>
+  (a -> f c) -> d (b a) -> f u
+firstTraverse f = cata @_ @_ @(b (f c)) (fmap embed . bisequenceA) . firstMap f
+
+instance Traversable List where
+  traverse f (List mu) = List <$> firstTraverse f mu

--- a/internal/src/Data/Path/Internal/Relativity.hs
+++ b/internal/src/Data/Path/Internal/Relativity.hs
@@ -2,7 +2,6 @@
 
 module Data.Path.Internal.Relativity (Relativity (..)) where
 
-import "base" Data.Bool (Bool ())
 import "base" Data.Eq (Eq)
 import "base" Data.Kind qualified as Kind
 import "base" Data.Ord (Ord)
@@ -30,7 +29,7 @@ data Relativity
   = -- | Absolute path
     Abs
   | -- | Relative path
-    Rel Bool
+    Rel
   | -- | `Relativity` unknown until runtime
     Any
   deriving stock (Eq, Generic, Ord, Read, Show)

--- a/internal/src/Data/Path/Internal/Resolution.hs
+++ b/internal/src/Data/Path/Internal/Resolution.hs
@@ -1,0 +1,15 @@
+{-# LANGUAGE Safe #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Data.Path.Internal.Resolution
+  ( Resolution (Unres, Res),
+  )
+where
+
+import "base" Data.Kind qualified as Kind
+
+type Resolution :: Kind.Type
+data Resolution
+  = Unres -- "../" allowed anywhere and in any number
+  | Res -- "../" - for 'Rel paths: disallowed at the beginning
+  -- "../" - for 'Abs paths: disallowed everywhere

--- a/path/src/Data/Path/Integration/Path.hs
+++ b/path/src/Data/Path/Integration/Path.hs
@@ -39,6 +39,7 @@ import safe "pathway-internal" Data.Path.Internal
     filename,
     parents,
   )
+import safe "pathway-internal" Data.Path.Internal.Resolution (Resolution (Unres))
 import safe "yaya" Yaya.Fold (Steppable)
 import safe "yaya" Yaya.Pattern (Maybe (Nothing), XNor (Both, Neither))
 import safe "yaya-unsafe" Yaya.Unsafe.Fold (unsafeAna)
@@ -63,7 +64,7 @@ extractDirectories ::
   (Steppable (->) t (XNor FilePath)) => Path.Path rel Path.Dir -> t
 extractDirectories = unsafeAna extractDirectory
 
-instance Pathish (Path.Path Path.Abs Path.Dir) 'Abs 'Dir FilePath where
+instance Pathish (Path.Path Path.Abs Path.Dir) 'Unres 'Abs 'Dir FilePath where
   specializePath path =
     Path
       { parents = (),
@@ -71,7 +72,7 @@ instance Pathish (Path.Path Path.Abs Path.Dir) 'Abs 'Dir FilePath where
         filename = Const ()
       }
 
-instance Pathish (Path.Path Path.Abs Path.File) 'Abs 'File FilePath where
+instance Pathish (Path.Path Path.Abs Path.File) 'Unres 'Abs 'File FilePath where
   specializePath path =
     Path
       { parents = (),
@@ -79,7 +80,7 @@ instance Pathish (Path.Path Path.Abs Path.File) 'Abs 'File FilePath where
         filename = pure . toText $ Path.filename path
       }
 
-instance Pathish (Path.Path Path.Rel Path.Dir) ('Rel 'False) 'Dir FilePath where
+instance Pathish (Path.Path Path.Rel Path.Dir) 'Unres ('Rel 'False) 'Dir FilePath where
   specializePath path =
     Path
       { parents = Proxy,
@@ -87,7 +88,7 @@ instance Pathish (Path.Path Path.Rel Path.Dir) ('Rel 'False) 'Dir FilePath where
         filename = Const ()
       }
 
-instance Pathish (Path.Path Path.Rel Path.File) ('Rel 'False) 'File FilePath where
+instance Pathish (Path.Path Path.Rel Path.File) 'Unres ('Rel 'False) 'File FilePath where
   specializePath path =
     Path
       { parents = Proxy,
@@ -95,7 +96,7 @@ instance Pathish (Path.Path Path.Rel Path.File) ('Rel 'False) 'File FilePath whe
         filename = pure . toText $ Path.filename path
       }
 
-instance Pathish (Path.SomeBase Path.Dir) 'Any 'Dir FilePath where
+instance Pathish (Path.SomeBase Path.Dir) 'Unres 'Any 'Dir FilePath where
   specializePath = \case
     Path.Abs path ->
       Path
@@ -110,7 +111,7 @@ instance Pathish (Path.SomeBase Path.Dir) 'Any 'Dir FilePath where
           filename = Const ()
         }
 
-instance Pathish (Path.SomeBase Path.File) 'Any 'File FilePath where
+instance Pathish (Path.SomeBase Path.File) 'Unres 'Any 'File FilePath where
   specializePath = \case
     Path.Abs path ->
       Path

--- a/pathway/src/Data/Path.hs
+++ b/pathway/src/Data/Path.hs
@@ -47,6 +47,9 @@ module Data.Path
   )
 where
 
+-- TODO: `minusNaturalMaybe` is exported from Numeric.Natural starting with base-4.18 (GHC 9.6).
+
+import Data.Path.Internal.Resolution (Resolution (Res, Unres))
 import safe "base" Control.Applicative (pure)
 import safe "base" Control.Category (id, (.))
 import safe "base" Data.Bool (Bool (False, True))
@@ -60,7 +63,6 @@ import safe "base" Data.Maybe qualified as Lazy
 import safe "base" Data.Proxy (Proxy (Proxy))
 import safe "base" Data.Semigroup (Semigroup, (<>))
 import safe "base" Data.String (IsString, String)
--- TODO: `minusNaturalMaybe` is exported from Numeric.Natural starting with base-4.18 (GHC 9.6).
 import "base" GHC.Natural (minusNaturalMaybe)
 import safe "base" Numeric.Natural (Natural)
 import safe "extra" Data.List.Extra qualified as List
@@ -90,7 +92,7 @@ import safe "yaya" Yaya.Fold
   )
 import safe "yaya" Yaya.Fold.Native ()
 import safe "yaya" Yaya.Pattern
-  ( Maybe (Nothing),
+  ( Maybe (Just, Nothing),
     Pair ((:!:)),
     XNor (Both, Neither),
     fromMaybe,
@@ -126,9 +128,9 @@ null :: (Projectable (->) t (XNor a)) => t -> Bool
 null = isNeither . project
 
 -- | Convert an arbitrary path value to a specific path type.
-type Pathish :: Kind.Type -> Relativity -> Type -> Kind.Type -> Kind.Constraint
-class Pathish path (rel :: Relativity) (typ :: Type) rep where
-  specializePath :: path -> Path rel typ rep
+type Pathish :: Kind.Type -> Resolution -> Relativity -> Type -> Kind.Type -> Kind.Constraint
+class Pathish path (res :: Resolution) (rel :: Relativity) (typ :: Type) rep where
+  specializePath :: path -> Path res rel typ rep
 
 -- | This does not convert `AnyPath` to a more specific `Path` type (see
 --  `anchor` for that), but converts some path representation to a `Path`. So
@@ -137,7 +139,7 @@ class Pathish path (rel :: Relativity) (typ :: Type) rep where
 --  __NB__: This is the only instance needed by Pathway itself, but the class
 --          exists as an integration point for other libraries that have some
 --          typed path representation.
-instance Pathish (Path rel typ rep) rel typ rep where
+instance Pathish (Path res rel typ rep) res rel typ rep where
   specializePath = id
 
 -- | This is a path where we don’t know (at the type level) whether it’s
@@ -149,7 +151,7 @@ instance Pathish (Path rel typ rep) rel typ rep where
 --   generic operations like parsing and printing, with separate functions (like
 --  `anchor`) to lift the contained information to the type level.
 type AnyPath :: Kind.Type -> Kind.Type
-type AnyPath = Path 'Any 'Type.Any
+type AnyPath = Path 'Unres 'Any 'Type.Any
 
 -- -- | Convert an arbitrary value representing a path to `AnyPath`.
 -- --
@@ -169,11 +171,8 @@ instance Relative 'Abs where
 instance Relative 'Any where
   generalizeRelativity = id
 
-instance Relative ('Rel 'False) where
+instance Relative 'Rel where
   generalizeRelativity Proxy = pure 0
-
-instance Relative ('Rel 'True) where
-  generalizeRelativity = pure
 
 type Typey :: Type -> Kind.Constraint
 class Typey typ where
@@ -212,10 +211,13 @@ type Pathy rel typ = (Relative rel, Typey typ)
 -- defaultGeneralizePath Proxy Proxy =
 --   generalizePath @(Path rel typ rep) . specializePath
 
-type RelOps :: Relativity -> Kind.Constraint
-class RelOps rel where
-  ascendRelative :: Path rel 'Dir rep -> Path ('Rel 'True) 'Dir rep
-  reparentBy :: Natural -> Path rel typ rep -> Path ('Rel 'True) typ rep
+-- TODO: this is now a TOTAL type-level function (it wasn't). Is it important in any way?
+type RelOps :: Resolution -> Kind.Constraint
+class RelOps res where
+  -- | Move up one directory in the file hierarchy.
+  ascendRelative :: Path res 'Rel 'Dir rep -> Path 'Unres 'Rel 'Dir rep
+
+  reparentBy :: Natural -> Path res rel typ rep -> Path 'Unres 'Rel typ rep
 
   -- | Like `route`, but for reparented paths. Unlike `route`, this
   --   can fail. If the first argument is reparented more than the second
@@ -224,7 +226,8 @@ class RelOps rel where
   --
   -- -- prop> maybe True ((b ==) . (a </>)) $ maybeRoute @_ @Text @'File a b
   --
-  -- >>> maybeRoute @('Rel 'True) @Text [posix|../../d/e/|] [posix|../f/g/|]
+  -- TODO: edit this doc
+  -- >>> maybeRoute @('Rel 'True) @Unres @Text [posix|../../d/e/|] [posix|../f/g/|]
   -- Nothing
   --
   --   we can see why if we first convert them to absolute paths
@@ -264,20 +267,22 @@ class RelOps rel where
   -- - going from @e@ to @g@, instead, entails going /down into/ a directory,
   --   which obviously requires knowing the name of such a directory.
   maybeRoute ::
-    Path ('Rel 'True) 'Dir rep ->
-    Path rel typ rep ->
-    Maybe (Path ('Rel 'True) typ rep)
+    Path 'Unres 'Rel 'Dir rep ->
+    Path res 'Rel typ rep ->
+    Maybe (Path 'Unres 'Rel typ rep)
 
   -- | Like `maybeRoute`, but shortens the path as much as possible. This can
   --   only make a difference when both paths have the same amount of
   --   reparenting. E.g.
   --
+  -- TODO: edit this doc
   -- >>> toText Format.posix <$> maybeMinimalRoute @('Rel 'True) @Text [posix|../d/e/|] [posix|../d/f/|]
   -- Just "../f/"
   --
   --   whereas
   --
-  -- >>> toText Format.posix <$> maybeRoute @('Rel 'True) @Text [posix|../d/e/|] [posix|../d/f/|]
+  -- TODO: edit this doc
+  -- >>> toText Format.posix <$> maybeRoute @('Rel 'True) @Unres @Text [posix|../d/e/|] [posix|../d/f/|]
   -- Just "../../d/f/"
   --
   --   The thing to consider is that various operations can fail depending on how
@@ -286,12 +291,12 @@ class RelOps rel where
   --   absolute directory) less is safer. Carefully choosing and ordering path
   --   operations to minimize the partiality is worthwhile.
   maybeMinimalRoute ::
-    (Eq rep) =>
-    Path ('Rel 'True) 'Dir rep ->
-    Path rel typ rep ->
-    Maybe (Path ('Rel 'True) typ rep)
+    Eq rep =>
+    Path 'Unres 'Rel 'Dir rep ->
+    Path res 'Rel typ rep ->
+    Maybe (Path 'Unres 'Rel typ rep)
 
-instance RelOps ('Rel 'False) where
+instance RelOps 'Res where
   ascendRelative dir =
     if null $ directories dir
       then dir {parents = 1}
@@ -310,11 +315,11 @@ instance RelOps ('Rel 'False) where
       )
       $ minusNaturalMaybe 0 (parents from)
   maybeMinimalRoute ::
-    forall typ rep.
-    (Eq rep) =>
-    Path ('Rel 'True) 'Dir rep ->
-    Path ('Rel 'False) typ rep ->
-    Maybe (Path ('Rel 'True) typ rep)
+    forall typ rep res.
+    Eq rep =>
+    Path 'Unres 'Rel 'Dir rep ->
+    Path 'Res 'Rel typ rep ->
+    Maybe (Path 'Unres 'Rel typ rep)
   maybeMinimalRoute from to =
     if parents from == 0
       then
@@ -329,7 +334,7 @@ instance RelOps ('Rel 'False) where
                 }
       else Nothing
 
-instance RelOps ('Rel 'True) where
+instance RelOps 'Unres where
   ascendRelative dir =
     if null $ directories dir
       then dir {parents = parents dir + 1}
@@ -348,11 +353,11 @@ instance RelOps ('Rel 'True) where
       )
       $ minusNaturalMaybe (parents to) (parents from)
   maybeMinimalRoute ::
-    forall typ rep.
-    (Eq rep) =>
-    Path ('Rel 'True) 'Dir rep ->
-    Path ('Rel 'True) typ rep ->
-    Maybe (Path ('Rel 'True) typ rep)
+    forall typ rep res.
+    Eq rep =>
+    Path 'Unres 'Rel 'Dir rep ->
+    Path 'Unres 'Rel typ rep ->
+    Maybe (Path 'Unres 'Rel typ rep)
   maybeMinimalRoute from to =
     if parents from == parents to
       then
@@ -367,7 +372,7 @@ instance RelOps ('Rel 'True) where
                 }
       else maybeRoute from to
 
-reparent :: (RelOps rel) => Path rel typ rep -> Path ('Rel 'True) typ rep
+reparent :: RelOps res => Path res 'Rel typ rep -> Path 'Unres 'Rel typ rep
 reparent = reparentBy 1
 
 partitionCommonPrefix' ::
@@ -408,30 +413,30 @@ partitionCommonPrefix ::
 partitionCommonPrefix =
   gcata (distTuple embed) partitionCommonPrefix'
 
-type Routable :: Relativity -> Relativity -> Kind.Constraint
-class Routable from to where
+type Routable :: Resolution -> Relativity -> Resolution -> Kind.Constraint
+class Routable res rel res' where
   -- | Creates a path relative to the first argument that that points to the
   --   same location as the second argument.
   route ::
-    Path from 'Dir rep -> Path to typ rep -> Path ('Rel 'True) typ rep
+    Path res rel 'Dir rep -> Path res' rel typ rep -> Path 'Unres 'Rel typ rep
 
   -- | Creates a path relative to the first argument that that points to the
   --   same location as the second argument.
   minimalRoute ::
-    (Eq rep) =>
-    Path from 'Dir rep ->
-    Path to typ rep ->
-    Path ('Rel 'True) typ rep
+    Eq rep =>
+    Path res rel 'Dir rep ->
+    Path res' rel typ rep ->
+    Path 'Unres 'Rel typ rep
 
 -- |
 --
--- prop> maybe True (b ==) $ a </?> route  @_ @_ @Text @'File a b
-instance Routable 'Abs 'Abs where
+-- prop> maybe True (b ==) $ a </?> route @_ @_ @Unres @Text @'File a b
+-- TODO: review this
+instance Routable res 'Abs res' where
   route ::
-    forall typ rep.
-    Path 'Abs 'Dir rep ->
-    Path 'Abs typ rep ->
-    Path ('Rel 'True) typ rep
+    Path res 'Abs 'Dir rep ->
+    Path res''Dir rep 'Abs typ rep ->
+    Path 'Unres 'Rel typ rep
   route from to =
     Path
       { parents = length $ directories from,
@@ -439,11 +444,11 @@ instance Routable 'Abs 'Abs where
         filename = filename to
       }
   minimalRoute ::
-    forall typ rep.
-    (Eq rep) =>
-    Path 'Abs 'Dir rep ->
-    Path 'Abs typ rep ->
-    Path ('Rel 'True) typ rep
+    forall typ rep res.
+    Eq rep =>
+    Path res 'Abs 'Dir rep ->
+    Path res 'Abs typ rep ->
+    Path 'Unres 'Rel typ rep
   minimalRoute from to =
     let (_, (newFrom, newTo)) :: (List rep, (List rep, List rep)) =
           partitionCommonPrefix (reverse $ directories from) . reverse $
@@ -454,7 +459,7 @@ instance Routable 'Abs 'Abs where
             filename = filename to
           }
 
-instance Routable ('Rel 'False) ('Rel 'True) where
+instance Routable 'Res 'Rel 'Unres where
   route from to =
     Path
       { parents = length (directories from) + parents to,
@@ -462,11 +467,11 @@ instance Routable ('Rel 'False) ('Rel 'True) where
         filename = filename to
       }
   minimalRoute ::
-    forall typ rep.
-    (Eq rep) =>
-    Path ('Rel 'False) 'Dir rep ->
-    Path ('Rel 'True) typ rep ->
-    Path ('Rel 'True) typ rep
+    forall typ rep res.
+    Eq rep =>
+    Path 'Res 'Rel 'Dir rep ->
+    Path 'Unres 'Rel typ rep ->
+    Path 'Unres 'Rel typ rep
   minimalRoute from to =
     let (_, (newFrom, newTo)) :: (List rep, (List rep, List rep)) =
           partitionCommonPrefix (reverse $ directories from) . reverse $
@@ -477,7 +482,7 @@ instance Routable ('Rel 'False) ('Rel 'True) where
             filename = filename to
           }
 
-instance Routable ('Rel 'False) ('Rel 'False) where
+instance Routable 'Res 'Rel 'Res where
   route from to =
     Path
       { parents = length $ directories from,
@@ -485,11 +490,11 @@ instance Routable ('Rel 'False) ('Rel 'False) where
         filename = filename to
       }
   minimalRoute ::
-    forall typ rep.
-    (Eq rep) =>
-    Path ('Rel 'False) 'Dir rep ->
-    Path ('Rel 'False) typ rep ->
-    Path ('Rel 'True) typ rep
+    forall typ rep res.
+    Eq rep =>
+    Path 'Res 'Rel 'Dir rep ->
+    Path 'Res 'Rel typ rep ->
+    Path 'Unres 'Rel typ rep
   minimalRoute from to =
     let (_, (newFrom, newTo)) :: (List rep, (List rep, List rep)) =
           partitionCommonPrefix (reverse $ directories from) . reverse $
@@ -499,6 +504,13 @@ instance Routable ('Rel 'False) ('Rel 'False) where
             directories = reverse newTo,
             filename = filename to
           }
+
+-- | Type-level ternary function to compute TODO. add doc
+-- TODO: also `Min` needs to change name.
+type Min :: Relativity -> Resolution -> Resolution
+type family Min a b where
+  Min 'Abs 'Res = 'Res
+  Min _ _ = 'Unres
 
 -- | This is like `minimalRoute`, but trades off weakening the path for the
 --   possibility of failure.
@@ -508,34 +520,53 @@ instance Routable ('Rel 'False) ('Rel 'False) where
 --   of the first argument.
 --
 -- -- prop> isNothing (maybeMinimalRoute a b) ==> isNothing (routePrefix a b)
-type Prefixed :: Relativity -> Relativity -> Kind.Constraint
-class Prefixed rel rel' | rel -> rel' where
+type Prefixed :: Resolution -> Relativity -> Resolution -> Kind.Constraint
+class Prefixed res rel res' where
   -- | Returns `False` exactly when `routePrefix` would return `Nothing`.
   --
   -- -- prop> isPrefix a b == not (isNothing $ routePrefix a b)
-  isPrefix :: (Eq rep) => Path rel 'Dir rep -> Path rel typ rep -> Bool
+  isPrefix :: Eq rep => Path res rel 'Dir rep -> Path res' rel typ rep -> Bool
   isPrefix a = isJust . routePrefix a
 
   -- | If the first argument is a prefix of the second argument, it will remove
   --   the prefix, returning a relative path. If it’s not a prefix, it returns
   --  `Nothing`.
   routePrefix ::
-    (Eq rep) =>
-    Path rel 'Dir rep ->
-    Path rel typ rep ->
-    Maybe (Path rel' typ rep)
+    Eq rep =>
+    Path res rel 'Dir rep ->
+    Path res' rel typ rep ->
+    Maybe (Path (Min rel res') 'Rel typ rep)
 
-instance Prefixed 'Abs ('Rel 'False) where
+instance Prefixed 'Res 'Abs 'Res where
   routePrefix ::
-    forall typ rep.
-    (Eq rep) =>
-    Path 'Abs 'Dir rep ->
-    Path 'Abs typ rep ->
-    Maybe (Path ('Rel 'False) typ rep)
+    Eq rep =>
+    Path 'Res 'Abs 'Dir rep ->
+    Path 'Res 'Abs typ rep ->
+    Maybe (Path 'Res 'Rel typ rep)
   routePrefix from to =
     let (_, (a, b)) :: (List rep, (List rep, List rep)) =
-          partitionCommonPrefix (reverse $ directories from) . reverse $
-            directories to
+          partitionCommonPrefix `on` (reverse . runIdentity . directories) from to
+     in if null a
+          then
+            pure
+              Path
+                { parents = Proxy,
+                  directories = case reverse b of
+                                  (h:t) -> Just (h, Just <$> t)
+                                  [] -> Nothing,
+                  filename = filename to
+                }
+          else Nothing
+
+instance Prefixed 'Res 'Rel 'Res where
+  routePrefix ::
+    Eq rep =>
+    Path 'Res 'Rel 'Dir rep ->
+    Path 'Res 'Rel typ rep ->
+    Maybe (Path 'Unres 'Rel typ rep)
+  routePrefix from to =
+    let (_, (a, b)) :: (List rep, (List rep, List rep)) =
+          partitionCommonPrefix `on` (reverse . directories . weaken) from to
      in if null a
           then
             pure
@@ -546,36 +577,49 @@ instance Prefixed 'Abs ('Rel 'False) where
                 }
           else Nothing
 
-instance Prefixed ('Rel 'False) ('Rel 'False) where
+instance Prefixed 'Res 'Abs 'Unres where
   routePrefix ::
-    forall typ rep.
-    (Eq rep) =>
-    Path ('Rel 'False) 'Dir rep ->
-    Path ('Rel 'False) typ rep ->
-    Maybe (Path ('Rel 'False) typ rep)
-  routePrefix from to =
-    let (_, (a, b)) :: (List rep, (List rep, List rep)) =
-          partitionCommonPrefix (reverse $ directories from) . reverse $
-            directories to
-     in if null a
-          then
-            pure
-              Path
-                { parents = Proxy,
-                  directories = reverse b,
-                  filename = filename to
-                }
-          else Nothing
+    Eq rep =>
+    Path 'Res 'Abs 'Dir rep ->
+    Path 'Unres 'Abs typ rep ->
+    Maybe (Path 'Unres 'Rel typ rep)
+  routePrefix = undefined
+
+instance Prefixed 'Res 'Rel 'Unres where
+  routePrefix ::
+    Eq rep =>
+    Path 'Res 'Rel 'Dir rep ->
+    Path 'Unres 'Rel typ rep ->
+    Maybe (Path 'Unres 'Rel typ rep)
+  routePrefix = undefined
+
+instance Prefixed 'Unres 'Abs 'Res where
+  routePrefix ::
+    Eq rep =>
+    Path 'Unres 'Abs 'Dir rep ->
+    Path 'Res 'Abs typ rep ->
+    Maybe (Path 'Res 'Rel typ rep)
+  routePrefix = undefined
+
+instance Prefixed 'Unres 'Rel 'Res where
+  routePrefix ::
+    Eq rep =>
+    Path 'Unres 'Rel 'Dir rep ->
+    Path 'Res 'Rel typ rep ->
+    Maybe (Path 'Unres 'Rel typ rep)
+  routePrefix = undefined
+
+instance Prefixed 'Unres 'Abs 'Unres where
+  routePrefix ::
+    Eq rep =>
+    Path 'Unres 'Abs 'Dir rep ->
+    Path 'Unres 'Abs typ rep ->
+    Maybe (Path 'Unres 'Rel typ rep)
+  routePrefix = undefined
 
 -- | This instance likely isn’t useful directly, as it will simply fail more
 --   often than `maybeRoute`, with no improvement in the type.
-instance Prefixed ('Rel 'True) ('Rel 'True) where
-  routePrefix ::
-    forall typ rep.
-    (Eq rep) =>
-    Path ('Rel 'True) 'Dir rep ->
-    Path ('Rel 'True) typ rep ->
-    Maybe (Path ('Rel 'True) typ rep)
+instance Prefixed 'Unres 'Rel 'Unres where
   routePrefix from to =
     if parents from == parents to
       then
@@ -603,7 +647,7 @@ instance Substible String where
 instance Substible Text where
   replace = Text.replace
 
-escape' :: (Substible a) => MapF a a (a -> a) -> a -> a
+escape' :: Substible a => MapF a a (a -> a) -> a -> a
 escape' = \case
   TipF -> id
   BinF _ direct escaped fn fn' -> fn' . replace direct escaped . fn
@@ -634,22 +678,24 @@ anyToText format path =
 -- >>> toText Format.posix [posix|.be/|]
 -- ".be/"
 toText ::
-  (Pathy rel typ, IsString a, Semigroup a, Substible a) => Format a -> Path rel typ a -> a
+  (Pathy rel typ, IsString a, Semigroup a, Substible a) => Format a -> Path res rel typ a -> a
 toText format = anyToText format . unanchor
 
 -- __TODO__: This forms a `Prism'` with `weaken`.
-strengthen :: Path ('Rel 'True) typ rep -> Maybe (Path ('Rel 'False) typ rep)
-strengthen path =
-  if parents path == 0 then pure path {parents = Proxy} else Nothing
+strengthen :: Path 'Unres 'Rel typ rep -> Maybe (Path 'Res 'Rel typ rep)
+strengthen path = case directories path of
+  [] -> Just $ path { directories = Nothing }
+  (Just d:ds) -> Just $ path { directories = Just (d, ds) }
+  _ -> Nothing
 
 type Anchored :: Kind.Type -> Kind.Type
 data Anchored rep
-  = AbsDir (Path 'Abs 'Dir rep)
-  | AbsFile (Path 'Abs 'File rep)
-  | RelDir (Path ('Rel 'False) 'Dir rep)
-  | RelFile (Path ('Rel 'False) 'File rep)
-  | ReparentedDir (Path ('Rel 'True) 'Dir rep)
-  | ReparentedFile (Path ('Rel 'True) 'File rep)
+  = AbsDir (Path 'Res 'Abs 'Dir rep)
+  | AbsFile (Path 'Res 'Abs 'File rep)
+  | RelDir (Path 'Res ('Rel 'False) 'Dir rep)
+  | RelFile (Path 'Res ('Rel 'False) 'File rep)
+  | ReparentedDir (Path 'Unres ('Rel 'True) 'Dir rep)
+  | ReparentedFile (Path 'Unres ('Rel 'True) 'File rep)
 
 -- | Discover the specific type of a `Path`.
 anchor :: AnyPath rep -> Anchored rep
@@ -713,13 +759,13 @@ anchor path =
     )
     $ parents path
 
-forgetRelativity :: (Relative rel) => Path rel typ rep -> Path 'Any typ rep
+forgetRelativity :: Relative rel => Path res rel typ rep -> Path res 'Any typ rep
 forgetRelativity path = path {parents = generalizeRelativity $ parents path}
 
-forgetType :: (Typey typ) => Path rel typ rep -> Path rel 'Type.Any rep
+forgetType :: Typey typ => Path res rel typ rep -> Path res rel 'Type.Any rep
 forgetType path = path {filename = generalizeType $ filename path}
 
 -- | Forget the specific type of the path (which can be recovered with
 --  `anchor`).
-unanchor :: (Pathy rel typ) => Path rel typ rep -> AnyPath rep
+unanchor :: (Pathy rel typ) => Path res rel typ rep -> AnyPath rep
 unanchor = forgetRelativity . forgetType

--- a/pathway/src/Data/Path/Directory.hs
+++ b/pathway/src/Data/Path/Directory.hs
@@ -3,7 +3,6 @@
 module Data.Path.Directory
   ( ascendAbsolute,
     (</>),
-    (</?>),
     current,
     isCurrent,
     root,
@@ -19,7 +18,6 @@ import "base" Control.Category ((.))
 import "base" Data.Bool (Bool (False, True))
 import "base" Data.Function (($))
 import "base" Data.Functor.Const (Const (Const))
-import "base" Data.Ord ((<=))
 import "base" Data.Semigroup ((<>))
 import "pathway-internal" Data.Path.Internal
   ( List,
@@ -30,7 +28,7 @@ import "pathway-internal" Data.Path.Internal
     parents,
     (</>),
   )
-import "yaya" Yaya.Applied (drop, length, reverse, tail)
+import "yaya" Yaya.Applied (reverse, tail)
 import "yaya" Yaya.Fold (cata, embed)
 import "yaya" Yaya.Pattern (Maybe (Nothing), XNor (Both, Neither), xnor)
 import "this" Data.Path.Relativity (Relativity (Abs, Rel))
@@ -50,62 +48,30 @@ isNeither = xnor True (\_ _ -> False)
 
 -- | Move up one directory in the file hierarchy.
 ascendAbsolute ::
-  Path 'Abs 'Dir rep ->
+  Path res 'Abs 'Dir rep ->
   --  | `Nothing` if the provided directory @`==` `root`.
-  Maybe (Path 'Abs 'Dir rep)
+  Maybe (Path res 'Abs 'Dir rep)
 ascendAbsolute dir =
   if cata isNeither $ directories dir
     then Nothing
     else pure dir {directories = tail $ directories dir}
 
--- | Concatenate a reparented path onto an absolute directory.
---
---  __NB__: The precedence is carefully set so that cases like the one below can
---          be written without parentheses.
---
--- >>> :{
---   toText @_ @_ @Text Format.posix
---     <$> [posix|/|] </?> [posix|user/|] </> [posix|../usr/bine/|] <> [posix|../bin/|] </> [posix|env|]
--- :}
--- Just "/usr/bin/env"
---
---          Note the four operators used: `<$>`, `</?>`, `</>`, and `<>`. Any
---          change to fixity would cause this to collapse.
-(</?>) ::
-  Path 'Abs 'Dir rep ->
-  Path ('Rel 'True) typ rep ->
-  -- | `Nothing` when the child path is reparented above the root directory.
-  Maybe (Path 'Abs typ rep)
-parent </?> child =
-  if parents child <= length (directories parent)
-    then
-      pure
-        Path
-          { parents = (),
-            directories =
-              directories child <> drop (parents child) (directories parent),
-            filename = filename child
-          }
-    else Nothing
-
-infixr 5 </?>
-
-isCurrent :: Path ('Rel 'False) 'Dir rep -> Bool
+isCurrent :: Path res 'Rel 'Dir rep -> Bool
 isCurrent = cata isNeither . directories
 
-descendThrough :: Path rel 'Dir rep -> List rep -> Path rel 'Dir rep
+descendThrough :: Path res rel 'Dir rep -> List rep -> Path res rel 'Dir rep
 descendThrough directory newComponents =
   directory {directories = reverse newComponents <> directories directory}
 
-descendTo :: Path rel 'Dir rep -> rep -> Path rel 'Dir rep
+descendTo :: Path res rel 'Dir rep -> rep -> Path res rel 'Dir rep
 descendTo directory component =
   descendThrough directory . embed . Both component $ embed Neither
 
-root :: Path 'Abs 'Dir rep
+root :: Path res 'Abs 'Dir rep
 root = Path {parents = (), directories = embed Neither, filename = Const ()}
 
-isRoot :: Path 'Abs 'Dir rep -> Bool
+isRoot :: Path res 'Abs 'Dir rep -> Bool
 isRoot = cata isNeither . directories
 
-selectFile :: Path rel 'Dir rep -> rep -> Path rel 'File rep
+selectFile :: Path res rel 'Dir rep -> rep -> Path res rel 'File rep
 selectFile path fileName = path {filename = pure fileName}

--- a/pathway/src/Data/Path/File.hs
+++ b/pathway/src/Data/Path/File.hs
@@ -17,10 +17,10 @@ import "pathway-internal" Data.Path.Internal
   )
 import "this" Data.Path.Type (Type (Dir, File))
 
-basename :: Path rel 'File rep -> rep
+basename :: Path res rel 'File rep -> rep
 basename = runIdentity . filename
 
-directory :: Path rel 'File rep -> Path rel 'Dir rep
+directory :: Path res rel 'File rep -> Path res rel 'Dir rep
 directory file =
   Path
     { parents = parents file,

--- a/pathway/src/Data/Path/Parser.hs
+++ b/pathway/src/Data/Path/Parser.hs
@@ -39,6 +39,7 @@ import "pathway-internal" Data.Path.Internal
     filename,
     parents,
   )
+import "pathway-internal" Data.Path.Internal.Resolution (Resolution (Unres))
 import "yaya" Yaya.Applied (reverse')
 import "yaya" Yaya.Fold (Mu, Projectable, Steppable, cata, embed)
 import "yaya" Yaya.Pattern (Maybe (Nothing), XNor (Both, Neither))
@@ -198,7 +199,7 @@ path =
 --   separator on the final component.
 directory ::
   (MP.MonadParsec v s p, MP.Token s ~ Char, Monoid (MP.Tokens s)) =>
-  Format (MP.Tokens s) -> p (Path 'Any 'Dir (MP.Tokens s))
+  Format (MP.Tokens s) -> p (Path 'Unres 'Any 'Dir (MP.Tokens s))
 directory =
   fmap
     ( \(parents, dir, filenm) ->

--- a/pathway/src/Data/Path/TH.hs
+++ b/pathway/src/Data/Path/TH.hs
@@ -42,6 +42,7 @@ import "base" Prelude (fromIntegral)
 -- >>> :seti -XTypeApplications
 -- >>> import "base" Data.Bool (Bool (False))
 -- >>> import Data.Path (Relativity (Abs, Rel), Type (Dir, File))
+-- >>> import Data.Path.Internal.Resolution (Resolution(Unres))
 
 deconstructXNor :: (a -> TH.Exp) -> (b -> TH.Exp) -> XNor a b -> TH.Exp
 deconstructXNor f g =
@@ -96,17 +97,17 @@ pathQuoter format =
 
 -- |
 --
--- >>> [posix|/usr/bin/env|] :: Path 'Abs 'File String
+-- >>> [posix|/usr/bin/env|] :: Path 'Unres 'Abs 'File String
 -- Path {parents = (), directories = List (embed (Both "bin" (embed (Both "usr" (embed Neither))))), filename = Identity "env"}
 --
--- >>> [posix|.be/|] :: Path ('Rel 'False) ' Dir String
+-- >>> [posix|.be/|] :: Path 'Unres ('Rel 'False) ' Dir String
 -- Path {parents = Proxy, directories = List (embed (Both ".be" (embed Neither))), filename = Const ()}
 posix :: TH.QuasiQuoter
 posix = pathQuoter Format.posix
 
 -- |
 --
--- >>> [windows|\usr\bin\env|] :: Path 'Abs 'File String
+-- >>> [windows|\usr\bin\env|] :: Path 'Unres 'Abs 'File String
 -- Path {parents = (), directories = List (embed (Both "bin" (embed (Both "usr" (embed Neither))))), filename = Identity "env"}
 windows :: TH.QuasiQuoter
 windows = pathQuoter $ Format.windows Nothing

--- a/quickcheck/src/Test/Path/QuickCheck.hs
+++ b/quickcheck/src/Test/Path/QuickCheck.hs
@@ -2,7 +2,11 @@
 {-# LANGUAGE Safe #-}
 -- __NB__: Because of the nested `Parents` and `Filename` constraints.
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -Wno-unused-matches #-}
+{-# OPTIONS_GHC -Wno-unused-top-binds #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
 
 module Test.Path.QuickCheck
   ( arbitraryNonEmptyText,
@@ -23,6 +27,7 @@ import "pathway-internal" Data.Path.Internal
   )
 import "quickcheck-instances" Test.QuickCheck.Instances.Strict ()
 import "yaya-quickcheck" Yaya.QuickCheck.Fold (arbitrarySteppable)
+import Prelude qualified
 #if !MIN_VERSION_QuickCheck (2, 17, 0)
 import "base" Numeric.Natural (Natural)
 import "yaya" Yaya.Applied (naturals, take)
@@ -39,9 +44,10 @@ arbitraryPath ::
   QC.Gen (Parents rel) ->
   (QC.Gen rep -> QC.Gen (Filename typ rep)) ->
   QC.Gen rep ->
-  QC.Gen (Path rel typ rep)
+  QC.Gen (Path res rel typ rep)
 arbitraryPath rel typ rep =
-  Path <$> rel <*> arbitraryDirectories rep <*> typ rep
+  Prelude.undefined
+  --Path <$> rel <*> arbitraryDirectories rep <*> typ rep
 
 #if !MIN_VERSION_QuickCheck (2, 17, 0)
 instance QC.Arbitrary Natural where
@@ -51,12 +57,12 @@ instance QC.Arbitrary Natural where
 
 instance
   (QC.Arbitrary (Parents rel), QC.Arbitrary1 (Filename typ)) =>
-  QC.Arbitrary1 (Path rel typ)
+  QC.Arbitrary1 (Path res rel typ)
   where
   liftArbitrary = arbitraryPath QC.arbitrary QC.liftArbitrary
 
 instance
-  (QC.Arbitrary1 (Path rel typ), IsString rep) =>
-  QC.Arbitrary (Path rel typ rep)
+  (QC.Arbitrary1 (Path res rel typ), IsString rep) =>
+  QC.Arbitrary (Path res rel typ rep)
   where
   arbitrary = QC.liftArbitrary arbitraryNonEmptyText

--- a/system/pathway-system.cabal
+++ b/system/pathway-system.cabal
@@ -197,6 +197,7 @@ library
     filepath ^>= {1.4.2, 1.5.2},
     megaparsec ^>= {9.0.1, 9.2.1, 9.5.0, 9.7.0},
     pathway ^>= {0.0.1},
+    pathway-internal ^>= {0.0.1},
     time ^>= {1.9.3, 1.11.1, 1.12.2, 1.14, 1.15},
     transformers ^>= {0.5.6, 0.6.1},
   exposed-modules:

--- a/system/src/Filesystem/Path.hs
+++ b/system/src/Filesystem/Path.hs
@@ -114,6 +114,7 @@ import safe "pathway" Data.Path.Parser qualified as Parser
 import safe "pathway" Data.Path.Relativity (Relativity (Abs, Any, Rel))
 import safe "pathway" Data.Path.Type (Type (Dir, File))
 import safe "pathway" Data.Path.Type qualified as Type (Type (Any))
+import safe "pathway-internal" Data.Path.Internal.Resolution (Resolution (Unres))
 import safe "time" Data.Time.Clock (UTCTime)
 import safe "transformers" Control.Monad.Trans.Class (lift)
 import safe "transformers" Control.Monad.Trans.Except (ExceptT (ExceptT))
@@ -162,7 +163,7 @@ handleAnchoredFile handler = either (Left . ParseFailure) handler . fromPathRep
 absDirFromPathRep ::
   (Ord e) =>
   PathRep ->
-  Either (InternalFailure PathRep e) (Path 'Abs 'Dir PathComponent)
+  Either (InternalFailure PathRep e) (Path 'Unres 'Abs 'Dir PathComponent)
 absDirFromPathRep =
   let badType rel typ = Left . IncorrectResultType Abs Dir rel typ
    in handleAnchoredDir \case
@@ -180,8 +181,8 @@ dirFromPathRep ::
   Either
     (InternalFailure PathRep e)
     ( Either
-        (Path 'Abs 'Dir PathComponent)
-        (Path ('Rel 'False) 'Dir PathComponent)
+        (Path 'Unres 'Abs 'Dir PathComponent)
+        (Path 'Unres ('Rel 'False) 'Dir PathComponent)
     )
 dirFromPathRep =
   let badType rel typ = Left . IncorrectResultType Any Dir rel typ
@@ -197,7 +198,7 @@ dirFromPathRep =
 absFileFromPathRep ::
   (Ord e) =>
   PathRep ->
-  Either (InternalFailure PathRep e) (Path 'Abs 'File PathComponent)
+  Either (InternalFailure PathRep e) (Path 'Unres 'Abs 'File PathComponent)
 absFileFromPathRep =
   let badType rel typ = Left . IncorrectResultType Abs File rel typ
    in handleAnchoredFile \case
@@ -214,8 +215,8 @@ fileFromPathRep ::
   Either
     (InternalFailure PathRep e)
     ( Either
-        (Path 'Abs 'File PathComponent)
-        (Path ('Rel 'False) 'File PathComponent)
+        (Path 'Unres 'Abs 'File PathComponent)
+        (Path 'Unres ('Rel 'False) 'File PathComponent)
     )
 fileFromPathRep =
   let badType rel typ = Left . IncorrectResultType Abs File rel typ
@@ -233,7 +234,7 @@ fileFromPathRep =
 --   ExceptT
 --     (InternalFailure PathRep e)
 --     IO
---     (Either (Path 'Abs 'Dir PathComponent) (Path 'Abs 'File PathComponent))
+--     (Either (Path res 'Abs 'Dir PathComponent) (Path res 'Abs 'File PathComponent))
 -- absPathFromPathRep =
 --   let badType rel typ = Left . IncorrectResultType Abs Pathic rel typ
 --    in handleAnchoredPath \case
@@ -252,8 +253,8 @@ relPathFromPathRep ::
     ( Either
         (InternalFailure PathRep e)
         ( Either
-            (Path ('Rel 'False) 'Dir PathComponent)
-            (Path ('Rel 'False) 'File PathComponent)
+            (Path 'Unres ('Rel 'False) 'Dir PathComponent)
+            (Path 'Unres ('Rel 'False) 'File PathComponent)
         )
     )
 relPathFromPathRep base =
@@ -398,35 +399,35 @@ data ListFailure
   | LFAF ArgumentFailure
   deriving stock (Eq, Generic, Ord, Read, Show)
 
-createDirectory :: Path 'Abs 'Dir PathComponent -> ExceptT CreationFailure IO ()
+createDirectory :: Path 'Unres 'Abs 'Dir PathComponent -> ExceptT CreationFailure IO ()
 createDirectory = lift . Dir.createDirectory . toPathRep
 
 -- | Can perhaps unify this and the following definition depending on how we
 --   handle errors.
 createDirectoryIfMissing ::
-  Path 'Abs 'Dir PathComponent -> ExceptT MaybeCreationFailure IO ()
+  Path 'Unres 'Abs 'Dir PathComponent -> ExceptT MaybeCreationFailure IO ()
 createDirectoryIfMissing = lift . Dir.createDirectoryIfMissing False . toPathRep
 
 createDirectoryWithParentsIfMissing ::
-  Path 'Abs 'Dir PathComponent -> ExceptT MaybeParentCreationFailure IO ()
+  Path 'Unres 'Abs 'Dir PathComponent -> ExceptT MaybeParentCreationFailure IO ()
 createDirectoryWithParentsIfMissing =
   lift . Dir.createDirectoryIfMissing True . toPathRep
 
-removeDirectoryRecursive :: Path 'Abs 'Dir PathComponent -> IO ()
+removeDirectoryRecursive :: Path 'Unres 'Abs 'Dir PathComponent -> IO ()
 removeDirectoryRecursive = Dir.removeDirectoryRecursive . toPathRep
 
-removePathForcibly :: Path 'Abs 'Dir PathComponent -> IO ()
+removePathForcibly :: Path 'Unres 'Abs 'Dir PathComponent -> IO ()
 removePathForcibly = Dir.removePathForcibly . toPathRep
 
 listDirectory ::
   (Ord e) =>
-  Path 'Abs 'Dir PathComponent ->
+  Path 'Unres 'Abs 'Dir PathComponent ->
   ExceptT
     ListFailure
     IO
     ( [InternalFailure PathRep e],
-      ( [Path ('Rel 'False) 'Dir PathComponent],
-        [Path ('Rel 'False) 'File PathComponent]
+      ( [Path 'Unres ('Rel 'False) 'Dir PathComponent],
+        [Path 'Unres ('Rel 'False) 'File PathComponent]
       )
     )
 listDirectory dir =
@@ -447,15 +448,15 @@ listDirectory dir =
 --            which should be only that case)
 getDirectoryContents ::
   (Ord e) =>
-  Path 'Abs 'Dir PathComponent ->
+  Path 'Unres 'Abs 'Dir PathComponent ->
   ExceptT
     ListFailure
     IO
     ( [InternalFailure PathRep e],
       -- FIXME: The first element should be `Rel` `True`, but don’t yet have a
       --        function for that.
-      ( [Path ('Rel 'False) 'Dir PathComponent],
-        [Path ('Rel 'False) 'File PathComponent]
+      ( [Path 'Unres ('Rel 'False) 'Dir PathComponent],
+        [Path 'Unres ('Rel 'False) 'File PathComponent]
       )
     )
 getDirectoryContents dir =
@@ -474,12 +475,12 @@ getDirectoryContents dir =
 --  __TODO__: This should include `GetFailure`.
 getCurrentDirectory ::
   (Ord e) =>
-  ExceptT (InternalFailure PathRep e) IO (Path 'Abs 'Dir PathComponent)
+  ExceptT (InternalFailure PathRep e) IO (Path 'Unres 'Abs 'Dir PathComponent)
 getCurrentDirectory = ExceptT $ absDirFromPathRep <$> Dir.getCurrentDirectory
 
 getHomeDirectory ::
   (Ord e) =>
-  ExceptT (InternalFailure PathRep e) IO (Path 'Abs 'Dir PathComponent)
+  ExceptT (InternalFailure PathRep e) IO (Path 'Unres 'Abs 'Dir PathComponent)
 getHomeDirectory = ExceptT $ absDirFromPathRep <$> Dir.getHomeDirectory
 
 -- __TODO__: Fill in a lot of stuff
@@ -490,16 +491,16 @@ getHomeDirectory = ExceptT $ absDirFromPathRep <$> Dir.getHomeDirectory
 --   function).
 findExecutable ::
   (Ord e) =>
-  Path ('Rel 'True) 'File PathComponent ->
-  ExceptT (InternalFailure PathRep e) IO (Maybe (Path 'Abs 'File PathComponent))
+  Path 'Unres ('Rel 'True) 'File PathComponent ->
+  ExceptT (InternalFailure PathRep e) IO (Maybe (Path 'Unres 'Abs 'File PathComponent))
 findExecutable =
   ExceptT . fmap (traverse absFileFromPathRep) . Dir.findExecutable . toPathRep
 
 findFiles ::
   (Ord e) =>
-  [Path 'Abs 'Dir PathComponent] ->
-  Path ('Rel 'True) 'File PathComponent ->
-  IO [Either (InternalFailure PathRep e) (Path 'Abs 'File PathComponent)]
+  [Path 'Unres 'Abs 'Dir PathComponent] ->
+  Path 'Unres ('Rel 'True) 'File PathComponent ->
+  IO [Either (InternalFailure PathRep e) (Path 'Unres 'Abs 'File PathComponent)]
 findFiles dirs =
   fmap (fmap absFileFromPathRep)
     . Dir.findFiles (toPathRep <$> dirs)
@@ -519,10 +520,10 @@ findFiles dirs =
 findFilesWith ::
   forall e.
   (Ord e, Show e, Typeable e) =>
-  (Path 'Abs 'File PathComponent -> IO Bool) ->
-  [Path 'Abs 'Dir PathComponent] ->
-  Path ('Rel 'True) 'File PathComponent ->
-  ExceptT [InternalFailure PathRep e] IO [Path 'Abs 'File PathComponent]
+  (Path 'Unres 'Abs 'File PathComponent -> IO Bool) ->
+  [Path 'Unres 'Abs 'Dir PathComponent] ->
+  Path 'Unres ('Rel 'True) 'File PathComponent ->
+  ExceptT [InternalFailure PathRep e] IO [Path 'Unres 'Abs 'File PathComponent]
 findFilesWith pred dirs =
   ExceptT
     . fmap
@@ -539,31 +540,31 @@ findFilesWith pred dirs =
     . toPathRep
 
 getPermissions ::
-  (Typey typ) => Path 'Abs typ PathComponent -> IO Dir.Permissions
+  (Typey typ) => Path 'Unres 'Abs typ PathComponent -> IO Dir.Permissions
 getPermissions = Dir.getPermissions . toPathRep
 
 setPermissions ::
-  (Typey typ) => Path 'Abs typ PathComponent -> Dir.Permissions -> IO ()
+  (Typey typ) => Path 'Unres 'Abs typ PathComponent -> Dir.Permissions -> IO ()
 setPermissions = Dir.setPermissions . toPathRep
 
 copyPermissions ::
   (Typey typ, Typey typ') =>
-  Path 'Abs typ PathComponent ->
-  Path 'Abs typ' PathComponent ->
+  Path 'Unres 'Abs typ PathComponent ->
+  Path 'Unres 'Abs typ' PathComponent ->
   IO ()
 copyPermissions from = Dir.copyPermissions (toPathRep from) . toPathRep
 
-getAccessTime :: (Typey typ) => Path 'Abs typ PathComponent -> IO UTCTime
+getAccessTime :: (Typey typ) => Path 'Unres 'Abs typ PathComponent -> IO UTCTime
 getAccessTime = Dir.getAccessTime . toPathRep
 
-getModificationTime :: (Typey typ) => Path 'Abs typ PathComponent -> IO UTCTime
+getModificationTime :: (Typey typ) => Path 'Unres 'Abs typ PathComponent -> IO UTCTime
 getModificationTime = Dir.getModificationTime . toPathRep
 
-setAccessTime :: (Typey typ) => Path 'Abs typ PathComponent -> UTCTime -> IO ()
+setAccessTime :: (Typey typ) => Path 'Unres 'Abs typ PathComponent -> UTCTime -> IO ()
 setAccessTime = Dir.setAccessTime . toPathRep
 
 setModificationTime ::
-  (Typey typ) => Path 'Abs typ PathComponent -> UTCTime -> IO ()
+  (Typey typ) => Path 'Unres 'Abs typ PathComponent -> UTCTime -> IO ()
 setModificationTime = Dir.setModificationTime . toPathRep
 
 -- -- | Checks the filesystem for an object at the provided path and returns it
@@ -579,29 +580,29 @@ type FsOperations :: Type -> Kind.Constraint
 class FsOperations typ where
   canonicalizePath ::
     (Ord e) =>
-    Path 'Abs typ PathComponent ->
-    ExceptT (InternalFailure PathRep e) IO (Path 'Abs typ PathComponent)
+    Path 'Unres 'Abs typ PathComponent ->
+    ExceptT (InternalFailure PathRep e) IO (Path 'Unres 'Abs typ PathComponent)
   createLink ::
     (Relative rel) =>
-    Path rel typ PathComponent ->
-    Path 'Abs typ PathComponent ->
+    Path 'Unres rel typ PathComponent ->
+    Path 'Unres 'Abs typ PathComponent ->
     IO ()
-  doesExist :: Path 'Abs typ PathComponent -> IO Bool
+  doesExist :: Path 'Unres 'Abs typ PathComponent -> IO Bool
   getSymbolicLinkTarget ::
     (Ord e) =>
-    Path 'Abs typ PathComponent ->
+    Path 'Unres 'Abs typ PathComponent ->
     ExceptT
       (InternalFailure PathRep e)
       IO
       ( Either
-          (Path 'Abs typ PathComponent)
-          (Path ('Rel 'False) typ PathComponent)
+          (Path 'Unres 'Abs typ PathComponent)
+          (Path 'Unres ('Rel 'False) typ PathComponent)
       )
-  remove :: Path 'Abs typ PathComponent -> ExceptT DirRemovalFailure IO ()
-  removeLink :: Path 'Abs typ PathComponent -> IO ()
+  remove :: Path 'Unres 'Abs typ PathComponent -> ExceptT DirRemovalFailure IO ()
+  removeLink :: Path 'Unres 'Abs typ PathComponent -> IO ()
   rename ::
-    Path 'Abs typ PathComponent ->
-    Path 'Abs typ PathComponent ->
+    Path 'Unres 'Abs typ PathComponent ->
+    Path 'Unres 'Abs typ PathComponent ->
     ExceptT RenameFailure IO ()
 
 instance FsOperations 'Dir where

--- a/system/src/Filesystem/Path/Compat.hs
+++ b/system/src/Filesystem/Path/Compat.hs
@@ -19,6 +19,7 @@ import "directory" System.Directory qualified as Dir
 import safe "pathway" Data.Path (Path)
 import safe "pathway" Data.Path.Relativity (Relativity (Abs))
 import safe "pathway" Data.Path.Type (Type (Dir))
+import safe "pathway-internal" Data.Path.Internal.Resolution (Resolution (Unres))
 import safe "transformers" Control.Monad.Trans.Class (lift)
 import safe "transformers" Control.Monad.Trans.Except (ExceptT)
 import safe "this" Filesystem.Path qualified as Path
@@ -31,7 +32,7 @@ import safe "this" Filesystem.Path.Internal (PathComponent, toPathRep)
 --
 --  __NB__: Like the underlying `Dir.withCurrentDirectory`, this is _not_ thread-safe.
 withCurrentDirectory ::
-  Path 'Abs 'Dir PathComponent ->
+  Path 'Unres 'Abs 'Dir PathComponent ->
   IO a ->
   ExceptT (Either Path.GetFailure Path.SetFailure) IO a
 withCurrentDirectory newCurDir = lift . Dir.withCurrentDirectory (toPathRep newCurDir)

--- a/system/src/Filesystem/Path/Internal.hs
+++ b/system/src/Filesystem/Path/Internal.hs
@@ -16,6 +16,7 @@ import "filepath" System.FilePath (FilePath)
 import "pathway" Data.Path (Path, Pathy)
 import "pathway" Data.Path qualified as Path
 import "pathway" Data.Path.Format qualified as Format
+import "pathway-internal" Data.Path.Internal.Resolution (Resolution (Unres))
 
 -- |
 --
@@ -33,5 +34,5 @@ type PathRep = FilePath
 type PathComponent :: Kind.Type
 type PathComponent = String
 
-toPathRep :: (Pathy rel typ) => Path rel typ PathComponent -> PathRep
+toPathRep :: (Pathy rel typ) => Path 'Unres rel typ PathComponent -> PathRep
 toPathRep = Path.toText Format.local


### PR DESCRIPTION
The code I've committed so far is still work in progress, and it's not meant to be accepted yet, but just to have some early feedback.

I would keep committing on this branch until I get something mergeable.

For now, I've just
  - introduced a new `Resolution` type, and consequently the corresponding kind by promotion;
  - introduced a single ctor `ResolutionCtor` for such a type, and consequently the corresponding type by promotion;
  - added another type parameter to `Path` and passed corresponding argument where needed (somewhere a type variable, somewhere else the unit `ResolutionCtor` type; the only logic in doing so was to avoid compilation errors);
  - verified that `cabal build all && cabal test all` succeeds.

@sellout, how does it look?